### PR TITLE
Fix: compileren op macOS/Linux (padscheiding + SystemEvents cross-platform)

### DIFF
--- a/CryptoScanner.Core/Core/GlobalData.cs
+++ b/CryptoScanner.Core/Core/GlobalData.cs
@@ -765,7 +765,9 @@ public static class GlobalData
             AppDataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                 ApplicationParams.Options?.AppDataFolder ?? Constants.AppName);
             Directory.CreateDirectory(AppDataFolder);
-            AppDataFolder += @"\";
+            // Use the platform path separator; a hardcoded "\" produced invalid paths on macOS/Linux
+            // (e.g. ~/.config/CryptoScanBot\CryptoScanBot.db).
+            AppDataFolder += Path.DirectorySeparatorChar;
         }
         return AppDataFolder;
     }

--- a/CryptoScanner/CryptoScanner.csproj
+++ b/CryptoScanner/CryptoScanner.csproj
@@ -54,7 +54,10 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 		<PackageReference Include="Microsoft.Diagnostics.Runtime" Version="4.0.732401" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.10" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+		<!-- Referenced on all platforms so PowerMonitorService.cs compiles on macOS/Linux. The package
+		     restores cross-platform; its Windows-only APIs stay guarded by OperatingSystem.IsWindows()
+		     at runtime. (Alternative: keep it Windows-only and guard the consuming code instead.) -->
+		<PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.10" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 		<PackageReference Include="WebView.Avalonia" Version="11.0.0.1" />
 		<PackageReference Include="WebView.Avalonia.Desktop" Version="11.0.0.1" />


### PR DESCRIPTION
Hoi Marius,

Twee kleine fixes zodat het project ook native op **macOS/Linux** compileert. Ik (Inge) bouw een cross-platform UI bovenop de engine en kwam deze twee tegen bij het native bouwen op Mac. Beide zijn minimaal en gerebased op de huidige `avalonia`.

### 1. Padscheiding voor de app-data-map (`GlobalData.cs`)
`AppDataFolder` kreeg er een hardcoded `"\"` achter geplakt. Op macOS/Linux geeft dat ongeldige paden (bijv. `~/.config/CryptoScanBot\CryptoScanBot.db`). Vervangen door `Path.DirectorySeparatorChar`, zodat het op elk platform klopt. Op Windows verandert er niets.

### 2. `Microsoft.Win32.SystemEvents` op alle platformen (`CryptoScanner.csproj`)
De package stond op Windows-only, maar `PowerMonitorService.cs` gebruikt 'm onvoorwaardelijk, waardoor het project niet compileert op macOS/Linux. De package restored cross-platform; de Windows-only API's blijven op runtime afgeschermd door `OperatingSystem.IsWindows()`.

> Alternatief: de package Windows-only houden en in plaats daarvan de *aanroepende* code afschermen. Ik heb voor de minimale variant gekozen, maar pas het graag aan naar jouw voorkeur.

### Niet nodig gebleken
Ik had lokaal ook de `TradingBuddyBabaOverlay`-registratie uitgezet om te kunnen bouwen, maar zag dat jij die inmiddels zelf al hebt uitgecommentarieerd upstream - dus daar zit niets in deze PR.

Laat maar weten wat je ervan vindt!