### PR TITLE
SignalR: Ready/Progress op barometer-DTO's + snellere push tijdens candle-load

### DIFF
--- a/CryptoScanner.Core/SignalR/CryptoSignalHub.cs
+++ b/CryptoScanner.Core/SignalR/CryptoSignalHub.cs
@@ -31,7 +31,15 @@ public class CryptoSignalHub : Hub
     /// </summary>
     public BarometerGraphDto GetBarometerGraph(string quote, string interval)
     {
-        var result = new BarometerGraphDto { Quote = quote, Interval = interval };
+        var result = new BarometerGraphDto
+        {
+            Quote = quote,
+            Interval = interval,
+            // Report the scanner's load state so the UI shows the loading skeleton and only draws the
+            // graph once candles are in. Set on every return path.
+            Ready = Core.GlobalData.ApplicationStatus == CryptoApplicationStatus.Running,
+            Progress = Core.GlobalData.CandleProgressText,
+        };
 
         if (Core.GlobalData.ActiveExchange == null)
             return result;

--- a/CryptoScanner.Core/SignalR/DashboardDataCollector.cs
+++ b/CryptoScanner.Core/SignalR/DashboardDataCollector.cs
@@ -47,15 +47,17 @@ public static class DashboardDataCollector
     {
         var dto = new DashboardUpdateDto();
 
+        // Barometer summary values (1h, 4h, 1d) + Ready/Progress. Filled unconditionally, before the
+        // exchange check below, so the UI's candle-load progress keeps flowing even during startup when
+        // ActiveExchange is still null.
+        dto.BarometerValues = GetBarometerValues(selectedQuote);
+
         var exchange = GlobalData.ActiveExchange;
         if (exchange == null)
             return dto;
 
         // Latest barometer point
         dto.LatestBarometerPoint = GetLatestBarometerPoint(selectedQuote, selectedInterval);
-
-        // Barometer summary values (1h, 4h, 1d)
-        dto.BarometerValues = GetBarometerValues(selectedQuote);
 
         // Market indicators (TradingView, F&G)
         lock (_lock)
@@ -108,7 +110,15 @@ public static class DashboardDataCollector
 
     private static BarometerValuesDto GetBarometerValues(string quote)
     {
-        var dto = new BarometerValuesDto { Quote = quote };
+        var dto = new BarometerValuesDto
+        {
+            Quote = quote,
+            // Ready/Progress mirror the scanner's own candle-load state so the UI can show a live
+            // "Loading candles N/M" line and flip the graph the instant loading finishes. Set first so
+            // they are always populated, even on the early returns below.
+            Ready = GlobalData.ApplicationStatus == CryptoApplicationStatus.Running,
+            Progress = GlobalData.CandleProgressText,
+        };
         var exchange = GlobalData.ActiveExchange;
         if (exchange == null || string.IsNullOrEmpty(quote))
             return dto;

--- a/CryptoScanner.Core/SignalR/DashboardDtos.cs
+++ b/CryptoScanner.Core/SignalR/DashboardDtos.cs
@@ -17,6 +17,12 @@ public class BarometerGraphDto
     public string Quote { get; set; } = "";
     public string Interval { get; set; } = "";
     public List<BarometerPointDto> Points { get; set; } = [];
+
+    /// <summary>True once the scanner has finished loading candles (ApplicationStatus == Running).</summary>
+    public bool Ready { get; set; }
+
+    /// <summary>Live "done / total (symbol)" candle-load progress while starting up; empty once ready.</summary>
+    public string Progress { get; set; } = "";
 }
 
 /// <summary>
@@ -29,6 +35,12 @@ public class BarometerValuesDto
     public decimal Barometer4h { get; set; }
     public decimal Barometer1d { get; set; }
     public string BarometerTime { get; set; } = "";
+
+    /// <summary>True once the scanner has finished loading candles (ApplicationStatus == Running).</summary>
+    public bool Ready { get; set; }
+
+    /// <summary>Live "done / total (symbol)" candle-load progress while starting up; empty once ready.</summary>
+    public string Progress { get; set; } = "";
 }
 
 /// <summary>

--- a/CryptoScanner.Core/SignalR/SignalRService.cs
+++ b/CryptoScanner.Core/SignalR/SignalRService.cs
@@ -21,6 +21,9 @@ public sealed class SignalRService : IDisposable
     private WebApplication? _app;
     private IHubContext<CryptoSignalHub>? _hubContext;
     private Timer? _dashboardTimer;
+    // Last time we broadcast the dashboard while Running - used to keep the ~1-minute cadence once the
+    // scanner is up, even though the timer itself now ticks every couple of seconds (for load progress).
+    private DateTime _lastRunningPushUtc = DateTime.MinValue;
     private bool _disposed;
 
     // The UI project sets these so the periodic push knows which quote/interval to broadcast.
@@ -85,7 +88,9 @@ public sealed class SignalRService : IDisposable
 
             _hubContext = _app.Services.GetRequiredService<IHubContext<CryptoSignalHub>>();
 
-            _dashboardTimer = new Timer(OnDashboardTimerTick, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+            // Tick every 2s so candle-load progress can be pushed live; once Running the tick throttles
+            // itself back to a ~1-minute broadcast cadence (see OnDashboardTimerTick).
+            _dashboardTimer = new Timer(OnDashboardTimerTick, null, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2));
 
             GlobalData.AddTextToLogTab($"SignalR server started on http://localhost:{port}/signalr/signals");
             ScannerLog.Logger.Info($"SignalR server started on port {port}");
@@ -151,8 +156,15 @@ public sealed class SignalRService : IDisposable
         if (_hubContext == null || GlobalData.IsEmulatorMode)
             return;
 
-        if (GlobalData.ApplicationStatus != Enums.CryptoApplicationStatus.Running)
-            return;
+        // While the scanner is still loading candles (Initializing) push every tick (~2s) so the UI's
+        // "Loading candles N/M" progress stays in step. Once Running, throttle back to the original
+        // ~1-minute cadence (the timer keeps ticking at 2s, but we only broadcast once a minute).
+        if (GlobalData.ApplicationStatus == Enums.CryptoApplicationStatus.Running)
+        {
+            if (DateTime.UtcNow - _lastRunningPushUtc < TimeSpan.FromMinutes(1))
+                return;
+            _lastRunningPushUtc = DateTime.UtcNow;
+        }
 
         try
         {


### PR DESCRIPTION
Zoals afgesproken - dit dekt **punt 1 en 2** van de drie dingetjes voor de web-UI (punt 3, de `GetBarometerValues(quote)` RPC, is voor jou). Vervangt het eerdere aanbod van commit `dcbd10dc`: die zat in onze oude app-laag met andere DTO's en past niet meer op jouw dashboard-opzet, dus dit is een frisse implementatie bovenop `0adb969f`.

## 1. Ready + Progress op de barometer
- `Ready` (bool) + `Progress` (string) toegevoegd aan `BarometerValuesDto` en `BarometerGraphDto`.
- `Ready` = `ApplicationStatus == Running`; `Progress` = `GlobalData.CandleProgressText` (dezelfde "done / total (symbol)"-tekst die de app toont).
- Gezet bovenaan `GetBarometerValues` en in `GetBarometerGraph`, op elk return-pad, zodat ze altijd gevuld zijn - ook voordat de exchange/candles bestaan. `CollectUpdate` vult `BarometerValues` nu vóór de `ActiveExchange == null`-check, zodat laadvoortgang ook tijdens startup meekomt.

## 2. Snellere push tijdens het laden
- De dashboard-timer tikte 1x/minuut en `OnDashboardTimerTick` returnde tenzij `Running`, dus tijdens candle-load kwam er niets bij de UI binnen.
- Timer tikt nu elke ~2s: tijdens `Initializing` pushen we elke tik zodat de voortgang live meeloopt; zodra `Running` throttelen we terug naar de oude ~1-minuut cadans.

Additief en achter je bestaande SignalR-server; geen gedragsverandering zodra `Running`. Live getest op Mac (osx-arm64, self-contained): de web-UI toont tijdens startup nu "Loading candles... N/M (SYMBOL)" die ~elke 2s meeloopt, en de barometer-grafiek verschijnt direct zodra het laden klaar is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)