### PR TITLE
SignalR: GetBarometerValues(quote) RPC + BarometerTime fix

### DIFF
--- a/CryptoScanner.Core/SignalR/CryptoSignalHub.cs
+++ b/CryptoScanner.Core/SignalR/CryptoSignalHub.cs
@@ -10,6 +10,7 @@ namespace CryptoScanner.Core.SignalR;
 /// SignalR hub that broadcasts generated crypto signals to connected clients.
 /// Clients receive signals on the "ReceiveSignal" method.
 /// Clients can invoke GetBarometerGraph(quote, interval) for initial/switch data.
+/// Clients can invoke GetBarometerValues(quote) for the 1h/4h/1d summary of their own quote.
 /// </summary>
 public class CryptoSignalHub : Hub
 {
@@ -65,5 +66,16 @@ public class CryptoSignalHub : Hub
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Returns the barometer summary values (1h/4h/1d) for a given quote.
+    /// The dashboard push carries the quote selected in the desktop app; a remote client that lets the
+    /// user pick their own quote can call this to get the values for that quote instead.
+    /// Call this on connect and whenever the client switches quote.
+    /// </summary>
+    public BarometerValuesDto GetBarometerValues(string quote)
+    {
+        return DashboardDataCollector.GetBarometerValues(quote);
     }
 }

--- a/CryptoScanner.Core/SignalR/DashboardDataCollector.cs
+++ b/CryptoScanner.Core/SignalR/DashboardDataCollector.cs
@@ -108,7 +108,12 @@ public static class DashboardDataCollector
         };
     }
 
-    private static BarometerValuesDto GetBarometerValues(string quote)
+    /// <summary>
+    /// Returns the barometer summary values (1h/4h/1d) for a single quote. Public so the hub can expose
+    /// it as an RPC: the dashboard push always uses the quote selected in the desktop app, while a remote
+    /// client may be showing a different quote.
+    /// </summary>
+    public static BarometerValuesDto GetBarometerValues(string quote)
     {
         var dto = new BarometerValuesDto
         {

--- a/CryptoScanner.Core/SignalR/DashboardDataCollector.cs
+++ b/CryptoScanner.Core/SignalR/DashboardDataCollector.cs
@@ -132,6 +132,7 @@ public static class DashboardDataCollector
             return dto;
 
         CryptoIntervalPeriod[] periods = [CryptoIntervalPeriod.interval1h, CryptoIntervalPeriod.interval4h, CryptoIntervalPeriod.interval1d];
+        CandleTime? barometerTime = null;
         foreach (var period in periods)
         {
             var barometerData = exchange.Data.GetBarometer(quoteData.Name, period);
@@ -143,19 +144,21 @@ public static class DashboardDataCollector
                     dto.Barometer4h = barometerData.PriceBarometer.Value;
                 else if (period == CryptoIntervalPeriod.interval1d)
                     dto.Barometer1d = barometerData.PriceBarometer.Value;
+
+                // Track the most recent computed minute for the barometer timestamp (see below).
+                if (barometerData.PriceDateTime.HasValue &&
+                    (barometerTime == null || barometerData.PriceDateTime.Value > barometerTime.Value))
+                    barometerTime = barometerData.PriceDateTime.Value;
             }
         }
 
-        // Barometer time from 1m candle list
-        string symbolName = Constants.SymbolNameBarometerPrice + quote;
-        if (exchange.SymbolListName.TryGetValue(symbolName, out CryptoSymbol? symbol))
-        {
-            var interval1m = symbol.GetSymbolInterval(CryptoIntervalPeriod.interval1m);
-            if (interval1m.CandleList.Count > 0 && interval1m.CandleList.TryGetLastCandle(out var candle))
-            {
-                dto.BarometerTime = (candle.OpenTime + 1).ToDateTime().ToLocalTime().ToString("HH:mm");
-            }
-        }
+        // Barometer time. The barometer is computed per minute but stored under the aggregate interval
+        // periods (15m/1h/4h/1d, never 1m), so the "$BMP" symbol has no 1m candle list to read a time
+        // from - that lookup always came back empty. Use PriceDateTime from the barometer data we just
+        // fetched instead; it holds the OpenTime of the last computed minute. (+1 = the closing minute,
+        // matching the previous formatting.)
+        if (barometerTime.HasValue)
+            dto.BarometerTime = (barometerTime.Value + 1).ToDateTime().ToLocalTime().ToString("HH:mm");
 
         return dto;
     }


### PR DESCRIPTION
Twee kleine, puur additieve wijzigingen aan de SignalR-dashboard-API, in het verlengde van `GetBarometerGraph`.

## 1. `GetBarometerValues(quote)` als hub-RPC
De dashboard-push draagt de barometer-waardes (1h/4h/1d) voor de quote die in de Avalonia-app is geselecteerd (`SelectedQuote`). Een remote client die zijn eigen gebruiker een quote laat kiezen, kan die waardes daardoor niet los ophalen en moet tot de volgende push wachten.

`DashboardDataCollector.GetBarometerValues(string quote)` doet al precies het juiste en neemt de quote al als parameter - hij was alleen `private`. Nu `public` gemaakt en op de hub blootgesteld, net als de bestaande `GetBarometerGraph(quote, interval)`. Geen bestaand gedrag, DTO of push-pad gewijzigd.

## 2. Fix: `BarometerTime` kwam altijd leeg terug
`GetBarometerValues` las de laatste **1m**-candle van het `$BMP<quote>`-symbool voor `BarometerTime`. Maar de barometer wordt per minuut berekend en uitsluitend onder de aggregaat-periodes opgeslagen (15m/1h/4h/1d, nooit 1m - zie `BarometerTools.CalculateBarometerIntervals`). Die 1m-lijst is dus altijd leeg, waardoor `BarometerTime` altijd blanco bleef - zowel in de nieuwe RPC als in de desktop-push die dezelfde methode aanroept.

Fix: de tijd komt nu uit `barometerData.PriceDateTime` (de OpenTime van de laatst berekende minuut), die de loop toch al ophaalt voor de 1h/4h/1d-waardes. Meest recente over de drie periodes, geformatteerd als `HH:mm` (+1 = sluitminuut, zoals voorheen). De overbodige `$BMP`-symbool-lookup is verwijderd.

## Getest
Runtime-geverifieerd op een verse Mac-build (osx-arm64) via een SignalR-probe:
```
VALUES RPC USDT  1h=-0.31 4h=-0.06 1d=-0.27  time=13:09  Ready=true
```
De waardes matchen exact de laatste graph-punten; `time` is nu gevuld.

🤖 Generated with [Claude Code](https://claude.com/claude-code)